### PR TITLE
删除PreAuthKeyTag表，用json数组的形式将tag直接存进PreAuthKey的一个字段中

### DIFF
--- a/controller/cockpit_api_tenants.go
+++ b/controller/cockpit_api_tenants.go
@@ -211,9 +211,6 @@ func (c *Cockpit) ListPreAuthKeys(userID int64) ([]PreAuthKey, error) {
 }
 func (c *Cockpit) DestroyPreAuthKey(pak PreAuthKey) error {
 	return c.db.Transaction(func(db *gorm.DB) error {
-		if result := db.Unscoped().Where(PreAuthKeyACLTag{PreAuthKeyID: pak.ID}).Delete(&PreAuthKeyACLTag{}); result.Error != nil {
-			return result.Error
-		}
 
 		if result := db.Unscoped().Delete(pak); result.Error != nil {
 			return result.Error

--- a/controller/console_api_keys.go
+++ b/controller/console_api_keys.go
@@ -73,7 +73,7 @@ func (h *Mirage) CAPIGetKeys(
 	for _, key := range authKeys {
 		aclTags := []string{}
 		for _, tag := range key.ACLTags {
-			aclTags = append(aclTags, tag.Tag)
+			aclTags = append(aclTags, tag)
 		}
 		tmpAuthKey := Key{
 			Id:      key.Key[:12], //key.ID,

--- a/controller/db.go
+++ b/controller/db.go
@@ -58,11 +58,12 @@ func (dp *DataPool) InitMirageDB() error {
 		return err
 	}
 
-	err = dp.db.AutoMigrate(&PreAuthKeyACLTag{})
-	if err != nil {
-		return err
-	}
-
+	/*
+		err = dp.db.AutoMigrate(&PreAuthKeyACLTag{})
+		if err != nil {
+			return err
+		}
+	*/
 	err = dp.db.AutoMigrate(&Organization{})
 	if err != nil {
 		return err


### PR DESCRIPTION
删除PreAuthKeyTag，用PreAuthKey中的一个Json数组替代。这个Tag表只有这里用到了，可以压成一个字段，不用外键关联一张表